### PR TITLE
composer.json

### DIFF
--- a/Magento_v2.x/Magento Plugin V2.0/app/code/One97/Paytm/composer.json
+++ b/Magento_v2.x/Magento Plugin V2.0/app/code/One97/Paytm/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "One97/Paytm",
+"description": "Paytm Payment Gateway",
+  "require": {
+   "php": "~5.5.0|~5.6.0|~7.0.0"
+  },
+  "type": "magento2-module",
+  "version": "1.0",
+  "license": [
+    "OSL-3.0",
+    "AFL-3.0"
+  ],
+  "autoload": {
+    "files": [
+      "registration.php"
+    ]
+  }
+}


### PR DESCRIPTION
absence of this file breaks the readiness check for Magento 2.1.x and hence is required to maintain correct component dependency