### PR TITLE
Fix for order status not changing to "Complete" after shipment generation

### DIFF
--- a/Magento_v2.x/Magento Plugin V2.0/app/code/One97/Paytm/Plugin/Adminhtml/Order/Shipment/Save.php
+++ b/Magento_v2.x/Magento Plugin V2.0/app/code/One97/Paytm/Plugin/Adminhtml/Order/Shipment/Save.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace One97\Paytm\Plugin\Adminhtml\Order\Shipment;
+
+use Psr\Log\LoggerInterface;
+use Magento\Sales\Model\OrderFactory;
+
+class Save
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $_logger;
+
+    /**
+     * @var OrderFactory
+     */
+    protected $_order;
+
+    /**
+     * UpdateAttributes constructor.
+     */
+    public function __construct(
+        OrderFactory $order,
+        LoggerInterface $logger
+    )
+    {
+        $this->_order  = $order;
+        $this->_logger = $logger;
+    }
+
+    public function afterExecute(
+        \Magento\Shipping\Controller\Adminhtml\Order\Shipment\Save $save
+    )
+    {
+        $order = null;
+        try {
+            $order_id = $save->getRequest()->getParam('order_id');
+            $order = $this->_order->create()->load($order_id);
+        } catch (\Exception $e) {
+        }
+        if(!$order) {
+            $this->_logger->debug("Order not found");
+        } else {
+            if (!$order->canUnhold() || !$order->canShip() || !$order->isCanceled() || !$order->canInvoice()) {
+                if($order->getStatus() != $order::STATE_COMPLETE) {
+                    $order->setStatus($order::STATE_COMPLETE);
+                    $order->setState($order::STATE_COMPLETE);
+                    $order->save();
+                }
+
+            }
+        }
+    }
+}

--- a/Magento_v2.x/Magento Plugin V2.0/app/code/One97/Paytm/etc/di.xml
+++ b/Magento_v2.x/Magento Plugin V2.0/app/code/One97/Paytm/etc/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Shipping\Controller\Adminhtml\Order\Shipment\Save">
+        <plugin name="ShipmentSavePlugin" type="One97\Paytm\Plugin\Adminhtml\Order\Shipment\Save"/>
+    </type>
+</config>


### PR DESCRIPTION
added plugin to force set Order status to "Complete" after all shipments for given order are generated